### PR TITLE
Fix AsyncNTLookupRequest action

### DIFF
--- a/src/VmgLtd/HlrLookupClient.php
+++ b/src/VmgLtd/HlrLookupClient.php
@@ -172,7 +172,7 @@ class HlrLookupClient {
             http_build_query(array(
                 'username' => $this->username,
                 'password' => $this->password,
-                'action' => 'submitAsyncLookupRequest',
+                'action' => 'submitAsyncNumberTypeLookupRequest',
                 'numbers' => self::convertMsisdnsArrayToString($numbers),
                 'route' => $route ? $route : null,
                 'storage' => $storage ? $storage : null


### PR DESCRIPTION
in **submitAsyncNumberTypeLookupRequest** action must be **submitAsyncNumberTypeLookupRequest**

as it gives error every time when i try to use this method that it looks for **msisdns** field

![screenshot from 2017-05-16 21-54-05](https://cloud.githubusercontent.com/assets/17250137/26125928/ff932564-3a83-11e7-8389-3b67e777a261.png)
